### PR TITLE
Fix in is_installed funct: actually doesn't handle missing packages properly.

### DIFF
--- a/oh-my-box.sh
+++ b/oh-my-box.sh
@@ -64,15 +64,20 @@ Options:
 # Please make sure you are using supported versions as mentioned
 # above on script doc (REQUIREMENTS section).
 is_installed(){
+	# If failure, don't return immediately;
+	# Check requirements once for all.
+	ret_code=0
 
 	for tool_name in $@; do
-		[ `which $tool_name` ] || echo "'$tool_name' is not installed !" || exit 1
+		[ `which $tool_name` ] || (echo "'$tool_name' is not installed !"; ret_code=1)
 	done
+
+	return $ret_code
 }
 
 setup(){
 	# Check tools existance
-	is_installed 'VirtualBox' 'packer' 'vagrant'
+	is_installed 'VirtualBox' 'packer' 'vagrant' || exit $?
 }
 
 teardown(){


### PR DESCRIPTION
If check for requirements fails, the script doesn't exit and continues its execution instead.
This is due to a logical condition in `is_installed` function not being handled properly.

``` bash
[ `which $tool_name` ] || echo "'$tool_name' is not installed !" || exit 1
```

If `which` succeeds it may return `true`, this is O.K since the remaining part will not execute. But if it fails it may return `false`, this leads to the execution of the 2nd. part which is always `true` or in 99.999% of the time. We can easily infer that we will never reach the 3rd part. So we got this:

``` bash
hack || true || bad
```

The proper behaviour should be:

``` bash
hack || bad
```

This could be achieved by doing so (or similar):

``` bash
hack && true || bad # or hack || (true && bad)
```

Then I preferred that `is_installed()` doesn't terminate the script. Since `is_sth` tells us that it may return a truth. So I introduced a new variable `ret_code` to handle a state and moved the check part to `setup()` it may be the right place I don't know.
Check out my comments within the script for details. 
